### PR TITLE
Made blacklist lowercase to match the search/filter method used

### DIFF
--- a/src/modules/IsVegan.js
+++ b/src/modules/IsVegan.js
@@ -1,4 +1,5 @@
-import blacklist from '../util/nonvegan.json';
+import blacklistsource from '../util/nonvegan.json';
+var blacklist = blacklistsource.map(x => x.trim().toLowerCase());
 
 /**
  * This functions takes the given ingredient


### PR DESCRIPTION
The current implementation lower cases the ingredient to search for, and uses the case-sensitive filter method, thereby miss-labeling any ingredients that are uppercased in nonvegan.json. I've lowercased the case of the blacklist before it's used to ensure lower case is used both in the source data and the filter.