### PR TITLE
Fix checkIngredients export

### DIFF
--- a/src/modules/IngredientChecker.js
+++ b/src/modules/IngredientChecker.js
@@ -7,7 +7,7 @@ import { containsFlaggedIngredients } from './CanBeVegan';
  * @param {[string]} ingredientsToCheck - the list of ingredients to check
  * @return {nonvegan: [], flagged:[]} with nonvegan and flagged ingredients
  */
-export default function checkIngredients (ingredientsToCheck) {
+export function checkIngredients (ingredientsToCheck) {
   const filteredElements = {
     // check non vegan ingredient
     nonvegan: containsNonVeganIngredients(ingredientsToCheck),

--- a/test/IngredientChecker.test.js
+++ b/test/IngredientChecker.test.js
@@ -1,4 +1,4 @@
-import checkIngredients from '../src/modules/IngredientChecker';
+import { checkIngredients } from '../src/modules/IngredientChecker';
 
 test('should contain flagged ingredients but NO non-vegan ingredients', () => {
   expect(checkIngredients(['biotin', 'glycine', 'soy', 'garlic'])).toEqual(


### PR DESCRIPTION
`checkIngredients` can't be imported because in `index.js` it was imported as non-default export while in `IngredientsChecker.js` it was exported as default export. To fix the issue, update the default export in `IngredientsChecker.js` to non-default export.