### PR TITLE
chore: update nonvegan.json with L-cysteine hydrochloride

### DIFF
--- a/src/i18n/en/nonvegan.json
+++ b/src/i18n/en/nonvegan.json
@@ -404,6 +404,7 @@
     "keratin",
     "keratinamino acids",
     "l-cysteine",
+    "l-cysteine hydrochloride",
     "l-form",
     "l-form: see cysteine.",
     "l-lactic acid",


### PR DESCRIPTION
Noticed that when you search for L-cysteine hydrochloride, it comes back as being vegan